### PR TITLE
Allow direct delivery to internet with TLS

### DIFF
--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -58,10 +58,10 @@ relayhost = [{{ postfix_relayhost }}]:{{ postfix_relayhost_port }}
 smtp_sasl_auth_enable = {{ 'yes' if postfix_sasl_auth_enable else 'no' }}
 smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
 smtp_sasl_security_options = {{ postfix_sasl_security_options }}
+{% endif %}
+{% endif %}
 {% if postfix_relaytls %}
 smtp_use_tls = yes
 smtp_tls_security_level = encrypt
 smtp_tls_note_starttls_offer = yes
-{% endif %}
-{% endif %}
 {% endif %}


### PR DESCRIPTION
Hello

With relayhost left blank postfix undertakes direct delivery to the internet. This change allows relaytls to be enabled when this is the case, meaning the delivery is undertaken in a secure manner.

This seems to be mentioned adequately under [this page in the section "What delivery method: direct or indirect"](http://www.postfix.org/BASIC_CONFIGURATION_README.html) 

By making this change, we just leave relayhost out, making it blank as the default. 