### PR TITLE
use comment filter to support multiline ansible management message

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tests"]
-	path = tests
-	url = https://github.com/arillso/tests

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests"]
+	path = tests
+	url = https://github.com/arillso/tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 language: python
-#python: "2.7"
+# python: "2.7"
 
 # Use the new container infrastructure
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 language: python
-python: "2.7"
+#python: "2.7"
 
 # Use the new container infrastructure
 sudo: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,6 @@
 ---
 galaxy_info:
   role_name: postfix
-  description: Ansible Postfix Role by arillso
   author: arillso
   description: Ansible role for installing and Configuration Pstfix on installs RHEL/CentOS or Debian/Ubuntu.
   license: MIT

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 ---
-
 galaxy_info:
+  role_name: postfix
+  description: Ansible Postfix Role by arillso
   author: arillso
   description: Ansible role for installing and Configuration Pstfix on installs RHEL/CentOS or Debian/Ubuntu.
   license: MIT

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,7 +42,7 @@
     owner: root
     group: root
     mode: 0600
-  when: postfix_relayhost|bool != false
+  when: postfix_relayhost
   notify:
     - postmap sasl_passwd
     - restart postfix

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,7 +42,7 @@
     owner: root
     group: root
     mode: 0600
-  when: postfix_relayhost != false
+  when: postfix_relayhost|bool != false
   notify:
     - postmap sasl_passwd
     - restart postfix

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 disable_vrfy_command = {{ postfix_disable_vrfy_command }}
 # smtpd_banner = $myhostname ESMTP $mail_name

--- a/templates/sasl_passwd.j2
+++ b/templates/sasl_passwd.j2
@@ -1,3 +1,3 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 [{{ postfix_relayhost }}]:{{ postfix_relayhost_port }} {{ postfix_sasl_user }}:{{ postfix_sasl_password }}

--- a/vars/Suse.yml
+++ b/vars/Suse.yml
@@ -1,0 +1,10 @@
+---
+# vars file for arillso.postfix
+
+postfix_packages:
+    - postfix
+    - cyrus-sasl-plain
+    - cyrus-sasl
+    - mailx
+
+psotfix_daemon_directory: /usr/libexec/postfix


### PR DESCRIPTION
The current usage results in invalid configuration files if the variable `ansible_managed` contains a multiline message.

It's better to use the comment filter, which supports multiline management messages.